### PR TITLE
L4T 28.1 : set make -j argument to 4 (was 6)

### DIFF
--- a/scripts/makeKernel.sh
+++ b/scripts/makeKernel.sh
@@ -5,8 +5,8 @@ cd /usr/src/kernel/kernel-4.4
 make prepare
 make modules_prepare
 # Make alone will build the dts files too
-# make -j6
-make -j6 Image
+# make -j4
+make -j4 Image
 make modules
 make modules_install
 


### PR DESCRIPTION
Since TX1 has only 4 cores, perhaps `-j 4` might be better than `-j 6`.